### PR TITLE
Ensured canonical protocol handles https correctly

### DIFF
--- a/MarkupSEO.module
+++ b/MarkupSEO.module
@@ -242,7 +242,7 @@ class MarkupSEO extends WireData implements Module, ConfigurableModule {
 			}
 
 			if($configData['canonicalProtocol'] == 'https') {
-				$pageData['canonical'] = preg_replace('%^http%Uis', 'https', $page->httpUrl);
+				$pageData['canonical'] = preg_replace('%^https?%i', 'https', $page->httpUrl);
 			} else {
 				$pageData['canonical'] = $page->httpUrl;
 			}


### PR DESCRIPTION
Regex caused https to be replaced with httpss as only the http was matched. Now matching both ensuring https canonical always results in correct https protocol. Removed non-greedy modifier as unwanted/unnecessary behaviour in this case as well as dotall modifier since the match pattern does not include dot wildcard characters.