### PR TITLE
Use $configData['image'] as last option

### DIFF
--- a/MarkupSEO.module
+++ b/MarkupSEO.module
@@ -218,15 +218,16 @@ class MarkupSEO extends WireData implements Module, ConfigurableModule {
 						}
 					break;
 					case 'image': 
-						if($configData['image']) {
-							$pageData['image'] = $configData['image'];
-						} elseif($configData['imageSmart'] && count($page->get(implode('|', $configData['imageSmart']))) > 0) {
+						if($configData['imageSmart'] && count($page->get(implode('|', $configData['imageSmart']))) > 0) {
 							$imageFields = $page->get(implode('|', $configData['imageSmart']));
 							try {
 								$pageData['image'] = $page->get(implode('|', $configData['imageSmart']))->first()->httpUrl;
 							} catch (Exception $e) {
 								$pageData['image'] = $page->get(implode('|', $configData['imageSmart']))->httpUrl;
 							}
+						}
+						if(!$pageData['image'] && $configData['image']) {
+							$pageData['image'] = $configData['image'];
 						}
 					break;
 				}


### PR DESCRIPTION
this way the value of $configData['image'] is used as last option, when there is no image declared on the page and no smart image.