### PR TITLE
add multisite support

### DIFF
--- a/MarkupSEO.module
+++ b/MarkupSEO.module
@@ -187,6 +187,19 @@ class MarkupSEO extends WireData implements Module, ConfigurableModule {
 		// get config seo data
 		$configData = wire('modules')->getModuleConfigData($this);
 
+		// override styles for multisite module, if it's installed
+		if ($multiSite = $this->modules->getModule('Multisite', array('noPermissionCheck' => true, 'noInit' => true))) {
+			if ($this->config->MultisiteDomains && array_key_exists($multiSite->domain, $this->config->MultisiteDomains) && array_key_exists('markupSEO', $this->config->MultisiteDomains[$multiSite->domain])) {
+				$configDataOverrides = $this->config->MultisiteDomains[$multiSite->domain]['markupSEO']; // get special site data
+				$configData = array_merge($configData, $configDataOverrides); // merge module config data with config data for special site
+
+				// override data in module scope, otherwise the one from module settings will be used
+				foreach(self::getDefaultConfig() as $key => $value) {
+					if (array_key_exists($key, $configData)) $this->$key = $configData[$key];
+				}
+			}
+		}
+
 		foreach($pageData as $fieldKey => $fieldValue) {
 			// if the field has content we can continue
 			if($fieldValue != '') continue;


### PR DESCRIPTION
I really like your module and use it on almost every page. One of my projects uses the [Multisite](https://processwire.com/talk/topic/1025-multisite/) module. Now I need different settings for every page. Therefore I extended the config data from the Multisite module like this:

```php
$config->MultisiteDomains = array(
  'domain1.com' => array( 
    'root' => 'www.domain1.com' 
  ),
  'domain2.com' => array( 
    'root' => 'www.domain2.com', 
    'http404' => 1932,
    'markupSEO' => array(
      'piwikAnalyticsIDSite' => 12,
      'titleFormat' => '{title}'
    )
  )
);
```

The code checks whether the Multisite module is installed and overrides the module config data for this specific site. Unfortunately I found no way to hook into your module. If it's ok for you, it would be great to add this feature to your module. Thanks! 