### PR TITLE
Don't generate tag if no value

### DIFF
--- a/MarkupSEO.module
+++ b/MarkupSEO.module
@@ -372,6 +372,7 @@ class MarkupSEO extends WireData implements Module, ConfigurableModule {
 					$rendered .= '<link rel="canonical" href="'.$content.'" />'.PHP_EOL;
 					break;
 				default:
+					if ($content == '') break;
 					if (strstr($name, 'og:')) {
 						$rendered .= '<meta property="'.$name.'" content="'.$content.'" />'.PHP_EOL;
 					} else {


### PR DESCRIPTION
For example if not fill the keyword field, then no meta keywords tag will be generated in template