### PR TITLE
Fix error: illegal string offset in MarkupSEO.module on line 435

### DIFF
--- a/MarkupSEO.module
+++ b/MarkupSEO.module
@@ -426,7 +426,7 @@ class MarkupSEO extends WireData implements Module, ConfigurableModule {
 	private function parseCustom($custom) {
 		if(trim($custom) == '') return;
 
-		$return = '';
+		$return = array();
 		$lines = explode(PHP_EOL, $custom);
 		foreach($lines as $line) {
 			list($key, $value) = explode(':=', $line);


### PR DESCRIPTION
When I fill "other meta tags" I get a warning "Illegal string offset" starting from PHP 7.1. This little change fixes that warning.
